### PR TITLE
Use SQLite as database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 zig-out/
 zig-cache/
 
+db.sqlite
+
 .gyro/
 deps.zig
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ npm run build
 ## Usage
 
 ```
-Usage: nochfragen [-h] [--listen-address <IP:PORT>] [--redis-address <IP:PORT>] [--root-dir <PATH>]
+Usage: nochfragen [-h] [--listen-address <IP:PORT>] [--redis-address <IP:PORT>] [--sqlite-db <PATH>] [--root-dir <PATH>]
 
 Options:
 
@@ -49,6 +49,9 @@ Options:
 
         --redis-address <IP:PORT>
             Address to connect to redis
+
+        --sqlite-db <PATH>
+            Path to the SQLite database
 
         --root-dir <PATH>
             Path to the static HTML, CSS and JS content

--- a/backend/Context.zig
+++ b/backend/Context.zig
@@ -1,5 +1,6 @@
 const okredis = @import("okredis");
-const Client = okredis.BufferedClient;
+const sqlite = @import("sqlite");
 
-redis_client: Client,
+redis_client: okredis.BufferedClient,
+db: sqlite.Db,
 root_dir: []const u8,

--- a/backend/main.zig
+++ b/backend/main.zig
@@ -137,6 +137,7 @@ fn startServer(
             builder.post("/api/questions", questions.addQuestion),
             builder.delete("/api/questions", questions.deleteAllQuestions),
             builder.put("/api/question/:id", questions.modifyQuestion),
+            builder.delete("/api/question/:id", questions.deleteQuestion),
 
             builder.get("/api/export", questions.exportQuestions),
 

--- a/backend/main.zig
+++ b/backend/main.zig
@@ -113,6 +113,7 @@ fn startServer(
     });
     defer context.db.deinit();
     try questions.initializeDatabase(&context.db);
+    try surveys.initializeDatabase(&context.db);
 
     try fs.init(allocator, .{
         .dir_path = try std.fs.path.join(allocator, &.{ root_dir, "build" }),
@@ -144,6 +145,7 @@ fn startServer(
             builder.get("/api/surveys", surveys.listSurveys),
             builder.post("/api/surveys", surveys.addSurvey),
             builder.put("/api/survey/:id", surveys.modifySurvey),
+            builder.delete("/api/survey/:id", surveys.deleteSurvey),
         }),
     );
 }

--- a/backend/questions.zig
+++ b/backend/questions.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const http = @import("apple_pie");
-const okredis = @import("okredis");
-const Client = okredis.BufferedClient;
+const sqlite = @import("sqlite");
+
 const json = std.json;
 
 const Store = @import("sessions/Store.zig");
@@ -14,6 +14,107 @@ const badRequest = responses.badRequest;
 const ok = responses.ok;
 
 const max_question_len = 500;
+
+const create_table_questions_query =
+    \\CREATE TABLE IF NOT EXISTS "questions" (
+    \\  "id"  INTEGER NOT NULL UNIQUE,
+    \\  "text"  TEXT NOT NULL,
+    \\  "upvotes"  INTEGER NOT NULL,
+    \\  "state"  INTEGER NOT NULL,
+    \\  "created_at"  INTEGER NOT NULL,
+    \\  "modified_at"  INTEGER NOT NULL,
+    \\  "answering_at"  INTEGER NOT NULL,
+    \\  "answered_at"  INTEGER NOT NULL,
+    \\  PRIMARY KEY("id" AUTOINCREMENT)
+    \\);
+;
+
+const insert_question_query =
+    \\INSERT INTO questions(
+    \\  "text",
+    \\  "upvotes",
+    \\  "state",
+    \\  "created_at",
+    \\  "modified_at",
+    \\  "answering_at",
+    \\  "answered_at"
+    \\) VALUES(
+    \\  @text,
+    \\  @upvotes,
+    \\  @state,
+    \\  @created_at,
+    \\  @modified_at,
+    \\  @answering_at,
+    \\  @answered_at
+    \\);
+;
+
+const list_questions_visible_query = std.fmt.comptimePrint(
+    \\SELECT
+    \\  "id",
+    \\  "text",
+    \\  "upvotes",
+    \\  "state",
+    \\  "created_at",
+    \\  "modified_at",
+    \\  "answering_at",
+    \\  "answered_at"
+    \\FROM questions
+    \\WHERE
+    \\  state = {} OR
+    \\  state = {} OR
+    \\  state = {}
+, .{
+    @enumToInt(QuestionState.unanswered),
+    @enumToInt(QuestionState.answering),
+    @enumToInt(QuestionState.answered),
+});
+
+const list_questions_all_query =
+    \\SELECT
+    \\  "id",
+    \\  "text",
+    \\  "upvotes",
+    \\  "state",
+    \\  "created_at",
+    \\  "modified_at",
+    \\  "answering_at",
+    \\  "answered_at"
+    \\FROM questions
+;
+
+const increment_upvotes_query =
+    \\UPDATE questions SET upvotes = upvotes + 1 WHERE id = @id;
+;
+
+const modify_question_query =
+    \\UPDATE questions SET
+    \\  state = @state,
+    \\  modified_at = @modified_at
+    \\WHERE id = @id;
+;
+
+const answering_question_query = std.fmt.comptimePrint(
+    \\UPDATE questions SET
+    \\  state = {},
+    \\  answering_at = @answering_at
+    \\WHERE id = @id;
+, .{
+    @enumToInt(QuestionState.answering),
+});
+
+const answered_question_query = std.fmt.comptimePrint(
+    \\UPDATE questions SET
+    \\  state = {},
+    \\  answered_at = @answered_at
+    \\WHERE id = @id;
+, .{
+    @enumToInt(QuestionState.answered),
+});
+
+const delete_all_questions_query =
+    \\DELETE FROM questions;
+;
 
 const QuestionState = enum(u32) {
     hidden,
@@ -34,6 +135,7 @@ const QuestionState = enum(u32) {
 };
 
 const Question = struct {
+    id: u64 = 0, // TODO remove default value
     text: []const u8,
     upvotes: u32 = 0,
     state: QuestionState = .unanswered,
@@ -42,6 +144,7 @@ const Question = struct {
     answering_at: i64,
     answered_at: i64,
 };
+// TODO remove
 const QuestionInternal = struct {
     text: []const u8,
     upvotes: u32 = 0,
@@ -51,43 +154,58 @@ const QuestionInternal = struct {
     answering_at: i64 = -1,
     answered_at: i64 = -1,
 };
-
-const HSETQuestion = okredis.commands.hashes.HSET.forStruct(QuestionInternal);
-const HMGETQuestion = okredis.commands.hashes.HMGET.forStruct(QuestionInternal);
+const QuestionInternalWithoutId = struct {
+    text: sqlite.Text,
+    upvotes: u32 = 0,
+    state: u32 = @enumToInt(QuestionState.unanswered),
+    created_at: i64,
+    modified_at: i64 = -1,
+    answering_at: i64 = -1,
+    answered_at: i64 = -1,
+};
+// TODO rename to `QuestionInternal`
+const QuestionInternalSqlite = struct {
+    id: u64,
+    text: sqlite.Text,
+    upvotes: u32 = 0,
+    state: u32 = @enumToInt(QuestionState.unanswered),
+    created_at: i64,
+    modified_at: i64 = -1,
+    answering_at: i64 = -1,
+    answered_at: i64 = -1,
+};
 
 const QuestionIterator = struct {
     allocator: std.mem.Allocator,
-    redis_client: *Client,
-    end: u32,
-    id: u32,
+    statement: sqlite.DynamicStatement,
+    iterator: sqlite.Iterator(QuestionInternalSqlite),
 
-    pub fn init(allocator: std.mem.Allocator, redis_client: *Client) !QuestionIterator {
-        const question_range = try redis_client.send([2]?u32, .{
-            "MGET",
-            "nochfragen:questions-start",
-            "nochfragen:questions-end",
-        });
-        const start = question_range[0] orelse 0;
-        const end = question_range[1] orelse 0;
+    fn init(allocator: std.mem.Allocator, db: *sqlite.Db, include_hidden: bool) !QuestionIterator {
+        const query = if (include_hidden)
+            list_questions_all_query
+        else
+            list_questions_visible_query;
+
+        var statement = try db.prepareDynamic(query);
 
         return QuestionIterator{
             .allocator = allocator,
-            .redis_client = redis_client,
-            .end = end,
-            .id = start,
+            .statement = statement,
+            .iterator = try statement.iterator(QuestionInternalSqlite, .{}),
         };
     }
 
-    pub fn next(self: *QuestionIterator) !?Question {
-        if (self.id >= self.end) return null;
+    fn deinit(self: *QuestionIterator) void {
+        self.statement.deinit();
+    }
 
-        const key = try std.fmt.allocPrint(self.allocator, "nochfragen:questions:{}", .{self.id});
-        self.id += 1;
-
-        const question_internal = try self.redis_client.sendAlloc(QuestionInternal, self.allocator, HMGETQuestion.init(key));
+    fn next(self: *QuestionIterator) !?Question {
+        const question_internal_maybe = try self.iterator.nextAlloc(self.allocator, .{});
+        const question_internal = question_internal_maybe orelse return null;
 
         return Question{
-            .text = question_internal.text,
+            .id = question_internal.id,
+            .text = question_internal.text.data,
             .upvotes = question_internal.upvotes,
             .state = std.meta.intToEnum(QuestionState, question_internal.state) catch .deleted,
             .created_at = question_internal.created_at,
@@ -98,6 +216,10 @@ const QuestionIterator = struct {
     }
 };
 
+pub fn initializeDatabase(db: *sqlite.Db) !void {
+    try db.exec(create_table_questions_query, .{}, .{});
+}
+
 pub fn listQuestions(ctx: *Context, response: *http.Response, request: http.Request) !void {
     const allocator = request.arena;
 
@@ -105,23 +227,23 @@ pub fn listQuestions(ctx: *Context, response: *http.Response, request: http.Requ
     var session = store.get(allocator, request, "nochfragen_session");
     const logged_in = (try session.get(bool, "authenticated")) orelse false;
 
-    var iter = try QuestionIterator.init(allocator, &ctx.redis_client);
+    var iter = try QuestionIterator.init(allocator, &ctx.db, logged_in);
+    defer iter.deinit();
 
     var json_write_stream = std.json.writeStream(response.writer(), 4);
     try json_write_stream.beginArray();
 
     while (try iter.next()) |question| {
         if (question.state == .deleted) continue;
-        if (!logged_in and question.state == .hidden) continue;
 
-        const str_id = try std.fmt.allocPrint(allocator, "question:{}", .{iter.id - 1});
+        const str_id = try std.fmt.allocPrint(allocator, "question:{}", .{question.id});
         const upvoted = (try session.get(bool, str_id)) orelse false;
 
         try json_write_stream.arrayElem();
         try json_write_stream.beginObject();
 
         try json_write_stream.objectField("id");
-        try json_write_stream.emitNumber(iter.id - 1);
+        try json_write_stream.emitNumber(question.id);
 
         try json_write_stream.objectField("text");
         try json_write_stream.emitString(question.text);
@@ -150,7 +272,8 @@ pub fn exportQuestions(ctx: *Context, response: *http.Response, request: http.Re
     const logged_in = (try session.get(bool, "authenticated")) orelse false;
     if (!logged_in) return forbidden(response, "Forbidden");
 
-    var iter = try QuestionIterator.init(allocator, &ctx.redis_client);
+    var iter = try QuestionIterator.init(allocator, &ctx.db, true);
+    defer iter.deinit();
 
     try response.headers.put(
         "Content-Disposition",
@@ -194,14 +317,10 @@ pub fn addQuestion(ctx: *Context, response: *http.Response, request: http.Reques
     if (request_data.text.len == 0) return badRequest(response, "Empty question");
     if (request_data.text.len > max_question_len) return badRequest(response, "Maximum question length exceeded");
 
-    const new_end = try ctx.redis_client.send(i64, .{ "INCR", "nochfragen:questions-end" });
-    const id = new_end - 1;
-
-    const key = try std.fmt.allocPrint(allocator, "nochfragen:questions:{}", .{id});
-    try ctx.redis_client.send(void, HSETQuestion.init(key, .{
-        .text = request_data.text,
+    try ctx.db.exec(insert_question_query, .{}, QuestionInternalWithoutId{
+        .text = sqlite.Text{ .data = request_data.text },
         .created_at = std.time.timestamp(),
-    }));
+    });
 
     try ok(response);
 }
@@ -215,9 +334,6 @@ pub fn modifyQuestion(ctx: *Context, response: *http.Response, request: http.Req
     var session = store.get(allocator, request, "nochfragen_session");
     if (session.is_new) return forbidden(response, "Access denied");
 
-    const iter = try QuestionIterator.init(allocator, &ctx.redis_client);
-    if (id < iter.id or id >= iter.end) return badRequest(response, "Invalid ID");
-
     var token_stream = json.TokenStream.init(request.body());
     const request_data = json.parse(
         struct {
@@ -228,38 +344,42 @@ pub fn modifyQuestion(ctx: *Context, response: *http.Response, request: http.Req
         .{ .allocator = allocator },
     ) catch return badRequest(response, "Invalid JSON");
 
-    const key = try std.fmt.allocPrint(allocator, "nochfragen:questions:{}", .{id});
     if (request_data.upvote) {
         const str_id = try std.fmt.allocPrint(allocator, "question:{}", .{id});
 
         const upvoted = (try session.get(bool, str_id)) orelse false;
         if (upvoted) return forbidden(response, "Already upvoted");
 
-        try ctx.redis_client.send(void, .{ "HINCRBY", key, "upvotes", 1 });
+        try ctx.db.exec(increment_upvotes_query, .{}, .{ .id = id });
+
         try session.set(bool, str_id, true);
     } else {
         const logged_in = (try session.get(bool, "authenticated")) orelse false;
         if (!logged_in) return forbidden(response, "Forbidden");
 
-        const state = std.meta.intToEnum(QuestionState, request_data.state) catch return badRequest(response, "Invalid state");
-        const modified_at = switch (state) {
+        const state = std.meta.intToEnum(QuestionState, request_data.state) catch
+            return badRequest(response, "Invalid state");
+        switch (state) {
             // don't track these separately
-            .hidden => "modified_at",
-            .unanswered => "modified_at",
-            .deleted => "modified_at",
+            .hidden,
+            .unanswered,
+            .deleted,
+            => try ctx.db.exec(modify_question_query, .{}, .{
+                .state = request_data.state,
+                .modified_at = std.time.timestamp(),
+                .id = id,
+            }),
 
-            .answering => "answering_at",
-            .answered => "answered_at",
-        };
+            .answering => try ctx.db.exec(answering_question_query, .{}, .{
+                .answering_at = std.time.timestamp(),
+                .id = id,
+            }),
 
-        try ctx.redis_client.send(void, .{
-            "HSET",
-            key,
-            "state",
-            request_data.state,
-            modified_at,
-            std.time.timestamp(),
-        });
+            .answered => try ctx.db.exec(answered_question_query, .{}, .{
+                .answered_at = std.time.timestamp(),
+                .id = id,
+            }),
+        }
     }
 
     try ok(response);
@@ -273,7 +393,7 @@ pub fn deleteAllQuestions(ctx: *Context, response: *http.Response, request: http
     const logged_in = (try session.get(bool, "authenticated")) orelse false;
     if (!logged_in) return forbidden(response, "Forbidden");
 
-    try ctx.redis_client.send(void, .{ "COPY", "nochfragen:questions-end", "nochfragen:questions-start", "REPLACE" });
+    try ctx.db.exec(delete_all_questions_query, .{}, .{});
 
     try ok(response);
 }

--- a/backend/surveys.zig
+++ b/backend/surveys.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
 const http = @import("apple_pie");
-const okredis = @import("okredis");
-const Client = okredis.BufferedClient;
+const sqlite = @import("sqlite");
 const json = std.json;
 
 const Store = @import("sessions/Store.zig");
@@ -14,87 +13,189 @@ const ok = responses.ok;
 
 const max_question_len = 500;
 
+const create_table_surveys_query =
+    \\CREATE TABLE IF NOT EXISTS "surveys" (
+    \\  "id" INTEGER NOT NULL UNIQUE,
+    \\  "text" TEXT NOT NULL,
+    \\  "state" INTEGER NOT NULL,
+    \\  PRIMARY KEY("id" AUTOINCREMENT)
+    \\);
+;
+
+const create_table_survey_options_query =
+    \\CREATE TABLE IF NOT EXISTS "survey_options" (
+    \\  "id" INTEGER NOT NULL UNIQUE,
+    \\  "survey" INTEGER NOT NULL,
+    \\  "text" TEXT NOT NULL,
+    \\  "votes" INTEGER NOT NULL,
+    \\  PRIMARY KEY("id" AUTOINCREMENT),
+    \\  FOREIGN KEY("survey") REFERENCES "surveys"("id") ON DELETE CASCADE ON UPDATE CASCADE
+    \\);
+;
+
+const insert_survey_query =
+    \\INSERT INTO surveys(
+    \\  "text",
+    \\  "state"
+    \\) VALUES(
+    \\  @text,
+    \\  @state
+    \\) RETURNING "id";
+;
+
+const insert_survey_option_query =
+    \\INSERT INTO survey_options(
+    \\  "survey",
+    \\  "text",
+    \\  "votes"
+    \\) VALUES(
+    \\  @survey,
+    \\  @text,
+    \\  @votes
+    \\);
+;
+
+const list_surveys_visible_query = std.fmt.comptimePrint(
+    \\SELECT
+    \\  "id",
+    \\  "text",
+    \\  "state"
+    \\FROM surveys
+    \\WHERE state = {}
+, .{
+    @enumToInt(SurveyState.open),
+});
+
+const list_surveys_all_query =
+    \\SELECT
+    \\  "id",
+    \\  "text",
+    \\  "state"
+    \\FROM surveys
+;
+
+const list_survey_options_query =
+    \\SELECT
+    \\  "id",
+    \\  "text",
+    \\  "votes"
+    \\FROM survey_options
+    \\WHERE survey = @survey
+;
+
+const increment_votes_query =
+    \\UPDATE survey_options SET
+    \\  votes = votes + 1
+    \\WHERE id = @id AND survey = @survey;
+;
+
+const modify_survey_query =
+    \\UPDATE surveys SET
+    \\  state = @state
+    \\WHERE id = @id;
+;
+
+const delete_survey_query =
+    \\DELETE FROM surveys WHERE id = @id;
+;
+
 const SurveyState = enum(u32) {
     hidden,
     open,
-    deleted,
 };
 
 const Survey = struct {
+    id: u64,
     text: []const u8,
-    options_len: u32,
-    state: SurveyState = .hidden,
+    state: SurveyState,
+    options: []const Option,
+};
+
+const SurveyInternalWithoutId = struct {
+    text: sqlite.Text,
+    state: u32 = @enumToInt(SurveyState.hidden),
 };
 const SurveyInternal = struct {
-    text: []const u8,
-    options_len: u32,
+    id: u64,
+    text: sqlite.Text,
     state: u32 = @enumToInt(SurveyState.hidden),
 };
 
 const Option = struct {
+    id: u64,
     text: []const u8,
     votes: u32 = 0,
 };
 
-const HSETSurvey = okredis.commands.hashes.HSET.forStruct(SurveyInternal);
-const HMGETSurvey = okredis.commands.hashes.HMGET.forStruct(SurveyInternal);
-
-const HSETOption = okredis.commands.hashes.HSET.forStruct(Option);
-const HMGETOption = okredis.commands.hashes.HMGET.forStruct(Option);
+const OptionInternalWithoutId = struct {
+    text: sqlite.Text,
+    survey: u64,
+    votes: u32 = 0,
+};
+const OptionInternalWithoutSurvey = struct {
+    id: u64,
+    text: sqlite.Text,
+    votes: u32 = 0,
+};
 
 const SurveyIterator = struct {
     allocator: std.mem.Allocator,
-    redis_client: *Client,
-    end: u32,
-    id: u32,
+    db: *sqlite.Db,
+    statement: sqlite.DynamicStatement,
+    iterator: sqlite.Iterator(SurveyInternal),
 
-    pub fn init(allocator: std.mem.Allocator, redis_client: *Client) !SurveyIterator {
-        const survey_range = try redis_client.send([2]?u32, .{
-            "MGET",
-            "nochfragen:surveys-start",
-            "nochfragen:surveys-end",
-        });
-        const start = survey_range[0] orelse 0;
-        const end = survey_range[1] orelse 0;
+    pub fn init(allocator: std.mem.Allocator, db: *sqlite.Db, include_hidden: bool) !SurveyIterator {
+        const query = if (include_hidden)
+            list_surveys_all_query
+        else
+            list_surveys_visible_query;
+
+        var statement = try db.prepareDynamic(query);
 
         return SurveyIterator{
             .allocator = allocator,
-            .redis_client = redis_client,
-            .end = end,
-            .id = start,
+            .db = db,
+            .statement = statement,
+            .iterator = try statement.iterator(SurveyInternal, .{}),
         };
     }
 
-    const IteratorResult = struct {
-        survey: Survey,
-        options: [*]Option,
-    };
+    fn deinit(self: *SurveyIterator) void {
+        self.statement.deinit();
+    }
 
-    pub fn next(self: *SurveyIterator) !?IteratorResult {
-        if (self.id >= self.end) return null;
+    pub fn next(self: *SurveyIterator) !?Survey {
+        const survey_internal_maybe = try self.iterator.nextAlloc(self.allocator, .{});
+        const survey_internal = survey_internal_maybe orelse return null;
 
-        const key = try std.fmt.allocPrint(self.allocator, "nochfragen:surveys:{}", .{self.id});
-        const survey_internal = try self.redis_client.sendAlloc(SurveyInternal, self.allocator, HMGETSurvey.init(key));
-        const survey = Survey{
-            .text = survey_internal.text,
-            .options_len = survey_internal.options_len,
-            .state = std.meta.intToEnum(SurveyState, survey_internal.state) catch .deleted,
-        };
+        var options = std.ArrayList(Option).init(self.allocator);
 
-        const options = try self.allocator.alloc(Option, survey.options_len);
-        for (options) |*option, i| {
-            const option_key = try std.fmt.allocPrint(self.allocator, "nochfragen:surveys:{}:options:{}", .{ self.id, i });
-            option.* = try self.redis_client.sendAlloc(Option, self.allocator, HMGETOption.init(option_key));
+        var statement = try self.db.prepareDynamic(list_survey_options_query);
+        defer statement.deinit();
+
+        var iterator = try statement.iterator(OptionInternalWithoutSurvey, .{ .survey = survey_internal.id });
+        while (try iterator.nextAlloc(self.allocator, .{})) |option_internal| {
+            try options.append(.{
+                .id = option_internal.id,
+                .text = option_internal.text.data,
+                .votes = option_internal.votes,
+            });
         }
 
-        self.id += 1;
-
-        return IteratorResult{
-            .survey = survey,
-            .options = options.ptr,
+        return Survey{
+            .id = survey_internal.id,
+            .text = survey_internal.text.data,
+            .state = std.meta.intToEnum(SurveyState, survey_internal.state) catch .open,
+            .options = options.items,
         };
     }
 };
+
+pub fn initializeDatabase(db: *sqlite.Db) !void {
+    _ = try db.pragma(void, .{}, "foreign_keys", "1");
+    try db.exec(create_table_surveys_query, .{}, .{});
+    try db.exec(create_table_survey_options_query, .{}, .{});
+}
 
 pub fn listSurveys(ctx: *Context, response: *http.Response, request: http.Request) !void {
     const allocator = request.arena;
@@ -103,26 +204,20 @@ pub fn listSurveys(ctx: *Context, response: *http.Response, request: http.Reques
     var session = store.get(allocator, request, "nochfragen_session");
     const logged_in = (try session.get(bool, "authenticated")) orelse false;
 
-    var iter = try SurveyIterator.init(allocator, &ctx.redis_client);
+    var iter = try SurveyIterator.init(allocator, &ctx.db, logged_in);
 
     var json_write_stream = std.json.writeStream(response.writer(), 6);
     try json_write_stream.beginArray();
 
-    while (try iter.next()) |result| {
-        const survey = result.survey;
-        const options = result.options[0..survey.options_len];
-
-        if (survey.state == .deleted) continue;
-        if (!logged_in and survey.state == .hidden) continue;
-
-        const str_id = try std.fmt.allocPrint(allocator, "survey:{}", .{iter.id - 1});
+    while (try iter.next()) |survey| {
+        const str_id = try std.fmt.allocPrint(allocator, "survey:{}", .{survey.id});
         const voted = (try session.get(bool, str_id)) orelse false;
 
         try json_write_stream.arrayElem();
         try json_write_stream.beginObject();
 
         try json_write_stream.objectField("id");
-        try json_write_stream.emitNumber(iter.id - 1);
+        try json_write_stream.emitNumber(survey.id);
 
         try json_write_stream.objectField("text");
         try json_write_stream.emitString(survey.text);
@@ -135,9 +230,12 @@ pub fn listSurveys(ctx: *Context, response: *http.Response, request: http.Reques
 
         try json_write_stream.objectField("options");
         try json_write_stream.beginArray();
-        for (options) |option| {
+        for (survey.options) |option| {
             try json_write_stream.arrayElem();
             try json_write_stream.beginObject();
+
+            try json_write_stream.objectField("id");
+            try json_write_stream.emitNumber(option.id);
 
             try json_write_stream.objectField("text");
             try json_write_stream.emitString(option.text);
@@ -177,18 +275,15 @@ pub fn addSurvey(ctx: *Context, response: *http.Response, request: http.Request)
     if (request_data.text.len > max_question_len) return badRequest(response, "Maximum question length exceeded");
     if (request_data.options.len == 0) return badRequest(response, "No options provided");
 
-    const new_end = try ctx.redis_client.send(i64, .{ "INCR", "nochfragen:surveys-end" });
-    const id = new_end - 1;
+    const survey_id = (try ctx.db.one(u64, insert_survey_query, .{}, SurveyInternalWithoutId{
+        .text = sqlite.Text{ .data = request_data.text },
+    })) orelse return error.InsertSurveyFailed;
 
-    const survey_key = try std.fmt.allocPrint(allocator, "nochfragen:surveys:{}", .{id});
-    try ctx.redis_client.send(void, HSETSurvey.init(survey_key, .{
-        .text = request_data.text,
-        .options_len = @intCast(u32, request_data.options.len),
-    }));
-
-    for (request_data.options) |option_text, i| {
-        const option_key = try std.fmt.allocPrint(allocator, "nochfragen:surveys:{}:options:{}", .{ id, i });
-        try ctx.redis_client.send(void, HSETOption.init(option_key, .{ .text = option_text }));
+    for (request_data.options) |option_text| {
+        try ctx.db.exec(insert_survey_option_query, .{}, OptionInternalWithoutId{
+            .survey = survey_id,
+            .text = sqlite.Text{ .data = option_text },
+        });
     }
 
     try ok(response);
@@ -208,9 +303,6 @@ pub fn modifySurvey(
     var session = store.get(allocator, request, "nochfragen_session");
     if (session.is_new) return forbidden(response, "Access denied");
 
-    const iter = try SurveyIterator.init(allocator, &ctx.redis_client);
-    if (id < iter.id or id >= iter.end) return badRequest(response, "Invalid ID");
-
     var token_stream = json.TokenStream.init(request.body());
     const request_data = json.parse(
         struct {
@@ -229,19 +321,48 @@ pub fn modifySurvey(
             if (voted) return forbidden(response, "Already voted");
 
             const vote = request_data.vote;
-            const key = try std.fmt.allocPrint(allocator, "nochfragen:surveys:{}:options:{}", .{ id, vote });
-            try ctx.redis_client.send(void, .{ "HINCRBY", key, "votes", 1 });
+
+            try ctx.db.exec(increment_votes_query, .{}, .{
+                .id = vote,
+                .survey = id,
+            });
+
             try session.set(bool, str_id, true);
         },
         1 => {
             const logged_in = (try session.get(bool, "authenticated")) orelse false;
             if (!logged_in) return forbidden(response, "Forbidden");
 
-            const key = try std.fmt.allocPrint(allocator, "nochfragen:surveys:{}", .{id});
-            try ctx.redis_client.send(void, .{ "HSET", key, "state", request_data.state });
+            _ = std.meta.intToEnum(SurveyState, request_data.state) catch
+                return badRequest(response, "Invalid state");
+
+            try ctx.db.exec(modify_survey_query, .{}, .{
+                .state = request_data.state,
+                .id = id,
+            });
         },
         else => return badRequest(response, "Invalid mode"),
     }
+
+    try ok(response);
+}
+
+pub fn deleteSurvey(
+    ctx: *Context,
+    response: *http.Response,
+    request: http.Request,
+    raw_id: []const u8,
+) !void {
+    const allocator = request.arena;
+
+    const id = std.fmt.parseInt(u32, raw_id, 10) catch return badRequest(response, "Invalid ID");
+
+    var store = Store{ .redis_client = &ctx.redis_client };
+    var session = store.get(allocator, request, "nochfragen_session");
+    const logged_in = (try session.get(bool, "authenticated")) orelse false;
+    if (!logged_in) return forbidden(response, "Forbidden");
+
+    try ctx.db.exec(delete_survey_query, .{}, .{.id = id});
 
     try ok(response);
 }

--- a/build.zig
+++ b/build.zig
@@ -5,12 +5,26 @@ pub fn build(b: *std.build.Builder) void {
     const target = b.standardTargetOptions(.{});
     const mode = b.standardReleaseOptions();
 
+    const sqlite_root_path = std.fs.path.dirname(pkgs.sqlite.source.path).?;
+    const sqlite_include_path = b.pathJoin(&.{ sqlite_root_path, "c" });
+    const sqlite_src = b.pathJoin(&.{ sqlite_root_path, "c", "sqlite3.c" });
+
+    const sqlite_lib = b.addStaticLibrary("sqlite", null);
+    sqlite_lib.addCSourceFile(sqlite_src, &[_][]const u8{"-std=c99"});
+    sqlite_lib.linkLibC();
+    sqlite_lib.setTarget(target);
+    sqlite_lib.setBuildMode(mode);
+
     const server = b.addExecutable("nochfragen", "backend/main.zig");
     server.setTarget(target);
     server.setBuildMode(mode);
     server.use_stage1 = true;
     pkgs.addAllTo(server);
     server.install();
+
+    server.addIncludePath(sqlite_include_path);
+    server.linkLibC();
+    server.linkLibrary(sqlite_lib);
 
     const run_cmd = server.run();
     run_cmd.step.dependOn(b.getInstallStep());

--- a/gyro.lock
+++ b/gyro.lock
@@ -1,3 +1,4 @@
 git https://github.com/Luukdegram/apple_pie.git master src/apple_pie.zig 5eaaabdced4f9b8d6cee947b465e7ea16ea61f42
 git https://github.com/kristoff-it/zig-okredis.git master src/okredis.zig 96a3b98f88f4ea79fd9cce704f102f4b80921ba6
 git https://github.com/Hejsil/zig-clap.git master clap.zig 4f4196fc3bc95c4bd3b12ce2e4a5f1050742cd3c
+git https://github.com/vrischmann/zig-sqlite 32e8023978af198040d9053e97127d3d0bb5d99f sqlite.zig 32e8023978af198040d9053e97127d3d0bb5d99f

--- a/gyro.zzz
+++ b/gyro.zzz
@@ -21,3 +21,8 @@ deps:
       url: "https://github.com/Hejsil/zig-clap.git"
       ref: master
       root: clap.zig
+  sqlite:
+    git:
+      url: "https://github.com/vrischmann/zig-sqlite"
+      ref: 32e8023978af198040d9053e97127d3d0bb5d99f
+      root: sqlite.zig

--- a/src/Item.svelte
+++ b/src/Item.svelte
@@ -4,11 +4,12 @@
   export let item;
   export let loggedIn;
 
+  let deleted = false;
+
   const hidden = 0;
   const unanswered = 1;
-  const deleted = 2;
-  const answering = 3;
-  const answered = 4;
+  const answering = 2;
+  const answered = 3;
 
   async function upvote() {
     await fetch(`api/question/${item.id}`, {
@@ -26,9 +27,15 @@
       body: JSON.stringify({ upvote: false, state: state }),
     }).then(() => (item.state = state));
   }
+
+  async function deleteQuestion() {
+    await fetch(`api/question/${item.id}`, {
+      method: "DELETE",
+    }).then(() => (deleted = true));
+  }
 </script>
 
-{#if item.state !== deleted}
+{#if !deleted}
   <li
     class={item.state === answering
       ? "list-group-item active d-flex justify-content-between"
@@ -43,7 +50,7 @@
       <div class="btn-group" role="group">
         {#if loggedIn}
           <button
-            on:click={() => changeState(deleted)}
+            on:click={() => deleteQuestion()}
             type="button"
             class="btn btn-danger"
           >

--- a/src/Survey.svelte
+++ b/src/Survey.svelte
@@ -5,12 +5,13 @@
 
   let choice = -1;
 
+  let deleted = false;
+
   const vote = 0;
   const modifyState = 1;
 
   const hidden = 0;
   const visible = 1;
-  const deleted = 2;
 
   async function submit() {
     await fetch(`api/survey/${item.id}`, {
@@ -45,13 +46,8 @@
 
   async function del() {
     await fetch(`api/survey/${item.id}`, {
-      method: "PUT",
-      body: JSON.stringify({
-        mode: modifyState,
-        vote: 0,
-        state: deleted,
-      }),
-    }).then(() => (item.state = deleted));
+      method: "DELETE",
+    }).then(() => (deleted = true));
   }
 
   function calcPercent(votes) {
@@ -61,7 +57,7 @@
   }
 </script>
 
-{#if item.state !== deleted}
+{#if !deleted}
   <li class="list-group-item">
     <div class="d-flex w-100 justify-content-between">
       {item.text}
@@ -84,14 +80,14 @@
     </div>
 
     <div class="list-group">
-      {#each item.options as option, index}
+      {#each item.options as option}
         <label class="list-group-item">
           {#if !item.voted}
             <input
               class="form-check-input me-1"
               type="radio"
               bind:group={choice}
-              value={index}
+              value={option.id}
               disabled={item.voted}
             />
           {/if}


### PR DESCRIPTION
This PR changes the storage backend for questions and surveys from Redis to SQLite. Redis is still used for session management. A relational database such as SQLite has many advantages for storing the data behind questions and surveys.

#### Future Work

- Use prepared statements stored in thread-local variables